### PR TITLE
Fix ByteArray parsing

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -28,8 +28,11 @@ function readFile(devName, fileName) {
     let out = file.load_contents(null);
     let value = out[1];
     if (value) {
-        return ByteArray.toString(value).replace("\n", "");
-    }
+        if (!ByteArray.toString(value).match(/GjsModule byteArray/)) {
+            return ByteArray.toString(value).replace("\n", "");
+        }
+        return parseInt(value);
+   }
 
     return "";
 }


### PR DESCRIPTION
The ByteArray value wasn't being properly parsed. The extension was showing [object GjsModule byteArray]% instead of the proper value. This fixes the behavior for GNOME Shell 3.28.4.

References:
- https://github.com/thankjura/ds4battery/issues/4
- https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/pull/674